### PR TITLE
Make URI:s posix compliant

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -83,9 +83,9 @@ class Hydra {
             path = path.substring(0, path.length - 1);
         }
 
-        const uri_path = Path.join(this.options.prefix, version, path);
+        const uri_path = Path.posix.join(this.options.prefix, version, path);
         this.setVersion(uri_path, args.method, version);
-        args.path = Path.join(this.options.prefix, path);
+        args.path = Path.posix.join(this.options.prefix, path);
 
         if (isDefault) {
             // Hoek.assert(!this.defaultMatch(args.method, args.path), `Default route already exists for ${args.path}`);
@@ -161,7 +161,7 @@ internals.route  = function (request, reply) {
 
     if (version) {
         const splitPath = request.path.split(hydra.options.prefix);
-        parsed.pathname = Path.join(hydra.options.prefix, version, ...splitPath);
+        parsed.pathname = Path.posix.join(hydra.options.prefix, version, ...splitPath);
         const path = Url.format(parsed);
         if (hydra.options.redirect) {
             return reply.redirect(path);


### PR DESCRIPTION
## what
Use `Path.posix.join()` instead of `Path.join()`

## why
Path.join is not safe to use on URI:s. On Windows, this would result in backslashes instead of forward slashes. Instead, we can use `url.resolve()` or `Path.posix.join()`

## references
https://nodejs.org/api/path.html#path_windows_vs_posix
https://stackoverflow.com/questions/16301503/can-i-use-requirepath-join-to-safely-concatenate-urls